### PR TITLE
Remove gitmoji hook from pre-commit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,10 +10,6 @@ repos:
     hooks:
     -   id: conventional-pre-commit
         stages: [commit-msg]
--   repo: https://github.com/ljnsn/cz-conventional-gitmoji
-    rev: v0.7.0
-    hooks:
-    -   id: conventional-gitmoji
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
     hooks:

--- a/template/{{.project_name}}/.pre-commit-config.yaml
+++ b/template/{{.project_name}}/.pre-commit-config.yaml
@@ -10,11 +10,6 @@ repos:
     hooks:
     -   id: conventional-pre-commit
         stages: [commit-msg]
-
--   repo: https://github.com/ljnsn/cz-conventional-gitmoji
-    rev: v0.7.0
-    hooks:
-    -   id: conventional-gitmoji
 -   repo: https://github.com/astral-sh/uv-pre-commit
     rev: 0.5.26
     hooks:


### PR DESCRIPTION
# Description

It got in the way of Semantic Release

## Changes

<!-- Link to the issue or tickets that this PR addresses -->

## Checklist

- [ ] Documented
- [ ] Tested
