### PR TITLE
Always include resources folder

### DIFF
--- a/template/__preamble.tmpl
+++ b/template/__preamble.tmpl
@@ -21,4 +21,6 @@ This file only provides template directives; it is skipped for the actual output
   {{skip "{{.project_name}}/notebooks/pipelines"}}
   {{skip "{{.project_name}}/resources/example-job.yml"}}
   {{skip "{{.project_name}}/resources/example-pipeline-job.yml"}}
+{{else}}
+  {{skip "{{.project_name}}/resources/.gitkeep"}}
 {{end}}

--- a/template/{{.project_name}}/resources/.gitkeep
+++ b/template/{{.project_name}}/resources/.gitkeep
@@ -1,0 +1,1 @@
+This folder is reserved for jobs and pipelines.


### PR DESCRIPTION
Include resources folder regardless of include_example_jobs parameter by including a conditional .gitkeep file