### PR TITLE
fix(template): cross-platform .justfile imports + dependabot pip grouping

### DIFF
--- a/template/{{.project_name}}/.github/dependabot.yml.tmpl
+++ b/template/{{.project_name}}/.github/dependabot.yml.tmpl
@@ -12,7 +12,7 @@ updates:
     directory: .
     schedule:
       interval: weekly
-      groups:
+    groups:
       dev-deps:
         dependency-type: development
       prod-deps:

--- a/template/{{.project_name}}/.justfile
+++ b/template/{{.project_name}}/.justfile
@@ -16,10 +16,10 @@ set dotenv-load
 set tempdir := ".just"
 
 # Imports Databricks Asset Bundle related recipes if they are deployed.
-import? '.just\dab.justfile'
+import? '.just/dab.justfile'
 
 # Imports VS Code related recipes if they are deployed.
-import? '.just\vscode.justfile'
+import? '.just/vscode.justfile'
 
 # Complete project setup: check tools, sync dependencies, set up git and pre-commit hooks
 [default]


### PR DESCRIPTION
## Summary
Two functional bugs in the generated-project template, both one-line fixes surfaced by a repo audit.

### 1. `.justfile` optional imports use Windows backslashes
`template/{{.project_name}}/.justfile` imported `'.just\dab.justfile'` and `'.just\vscode.justfile'`. `just`'s optional imports (`import?`) silently no-op when the path doesn't resolve, so on macOS/Linux the **core DAB and VS Code recipes were silently dropped** from generated projects. Switched both to forward slashes, matching the existing `'.just/shell_settings.justfile'` import on line 7 (forward slashes resolve on all platforms).

### 2. dependabot pip `groups:` mis-indented
In `dependabot.yml.tmpl` the pip block's `groups:` key was nested under `schedule:` (6 spaces) instead of being a sibling (4 spaces), so the `dev-deps`/`prod-deps` grouping was silently ignored in every generated project. Dedented to mirror the working `github-actions` block above it.

## Test plan
- [ ] Verify a generated project loads the `dab`/`vscode` just recipes on macOS/Linux (`just --list`)
- [ ] Verify Dependabot accepts the `pip` grouping config
