### PR TITLE
docs: fix stale references and document empower_vscode parameter

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,7 +115,7 @@ High level walk-through:
 | `library/template_variables.tmpl` | Contains variable manipulations that are not directly derived from the cli-input and can be used throughout the template. |
 | `accelerators/*` | This directory is a work in progress and is not currently used. This is not a default component of Databricks custom bundle templates. |
 
-This repository also provides a `justfile` which can help you properly setup git hooks, which will keep your commits compliant with contributing-rules.
+This repository also provides a `.justfile` which can help you properly setup git hooks, which will keep your commits compliant with contributing-rules.
 
 ### databricks_template_schema
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This template solves common pain points in Databricks project setup:
 
 - **Streamlined Setup**: One command creates a fully configured development environment
 - **Modern Python Tooling**: Uses `uv` for fast package management, `ruff` for linting, and `ty` for type checking
-- **Modular Architecture**: Core template is lightweight with optional accelerators for specialized needs
+- **Modular Architecture**: Core template is lightweight, with experimental accelerators (work in progress) for specialized needs
 - **CI/CD Ready**: Complete pipelines for GitHub Actions and Azure DevOps
 - **Development Environment**: DevContainer and WSL support for consistent development across platforms
 
@@ -58,6 +58,7 @@ This template solves common pain points in Databricks project setup:
     | `include_example_jobs` | Whether to include example pipelines and jobs | `yes/no` | `setup_type` = `tailored` |
     | `support_windows` | Whether to include Windows support | `yes/no` | `setup_type` = `tailored` |
     | `include_dab_recipes` | Whether to include just recipes for Databricks Bundle commands | `yes/no` | `setup_type` = `tailored` |
+    | `empower_vscode` | Whether to include VS Code settings, extension recommendations, and just recipes | `yes/no` | `setup_type` = `tailored` |
 
     > Previously, specifying a `package_name` was required. The `package_name` is now automatically generated from the `project_name` by replacing dashes (`-`) with underscores (`_`) following Python package naming conventions.
 
@@ -71,6 +72,7 @@ This template solves common pain points in Databricks project setup:
     | `include_example_jobs` | `yes` | `no` |
     | `support_windows` | `yes` | `no` |
     | `include_dab_recipes` | `yes` | `no` |
+    | `empower_vscode` | `yes` | `no` |
 
 3. Set up a fully configured development environment by running:
 

--- a/template/{{.project_name}}/docs/README.md.tmpl
+++ b/template/{{.project_name}}/docs/README.md.tmpl
@@ -26,5 +26,5 @@
 
 ## Troubleshooting
 
-- Running `make clean` is probably a good start
+- Running `just clean` is probably a good start
 - Refer to the [Databricks documentation](https://docs.databricks.com/dev-tools/bundles/index.html) for bundle-specific questions

--- a/template/{{.project_name}}/docs/development.md.tmpl
+++ b/template/{{.project_name}}/docs/development.md.tmpl
@@ -8,11 +8,11 @@ The project is structured as follows:
 {{.project_name}}/{{if (eq .cicd_provider "azure")}}
 ├── .azure/                   # Azure DevOps pipelines{{end}}{{if (eq .cicd_provider "github")}}
 ├── .github/                        # GitHub Actions workflows{{end}}
+├── .just/                          # just recipe imports (DAB, VS Code, shell settings)
 ├── .vscode/                        # VSCode settings
 ├── docs/                           # Documentation
 ├── notebooks/                      # Databricks notebooks
 ├── resources/                      # Databricks resources (jobs, pipelines)
-├── scratch/                        # Personal, exploratory notebooks (gitignored)
 ├── src/                            # Source code
 ├── tests/                          # Tests
 ├── .gitignore                      # Git ignore patterns

--- a/template/{{.project_name}}/notebooks/pipelines/example-pipeline/README.md
+++ b/template/{{.project_name}}/notebooks/pipelines/example-pipeline/README.md
@@ -4,7 +4,6 @@ This folder defines all source code for the 'example' pipeline:
 
 - `explorations`: Ad-hoc notebooks used to explore the data processed by this pipeline.
 - `transformations`: All dataset definitions and transformations.
-- `utilities`: Utility functions and Python modules used in this pipeline.
 
 ## Getting Started
 


### PR DESCRIPTION
## Summary
Documentation drift cleanup surfaced by a repo audit. No functional changes.

- **`docs/README.md.tmpl`** — Troubleshooting suggested `make clean`, but generated projects ship a `.justfile` and no Makefile → `just clean`.
- **example-pipeline `README.md`** — Documented a `utilities` folder that doesn't exist (only `explorations/` and `transformations/` are scaffolded). Removed the bullet.
- **`development.md.tmpl`** — Project-structure tree listed a nonexistent `scratch/` directory and omitted the real `.just/` directory. Swapped them.
- **`CONTRIBUTING.md`** — Referred to a `justfile`; the actual file is the dotfile `.justfile`.
- **`README.md`**
  - The "Modular Architecture" bullet sold accelerators as a ready feature while `CONTRIBUTING.md` calls them a work in progress — softened to "experimental (work in progress)" so there's a single source of truth.
  - The `empower_vscode` parameter (defined in `databricks_template_schema.json`, order 41, default `yes`) was missing from both the prompt table and the defaults table. Added rows.

## Test plan
- [ ] Skim rendered docs; confirm no broken references remain
