### PR TITLE
chore: config parity and dead-target cleanup

### DIFF
--- a/release.config.mjs
+++ b/release.config.mjs
@@ -12,7 +12,7 @@ export default {
     [
       "@semantic-release/exec",
       {
-        prepareCmd: "sed -i 's/version `[0-9]\\+\\.[0-9]\\+\\.[0-9]\\+`/version `${nextRelease.version}`/g' template/{{.project_name}}/README.md.tmpl template/{{.project_name}}/docs/README.md.tmpl || true",
+        prepareCmd: "sed -i 's/version `[0-9]\\+\\.[0-9]\\+\\.[0-9]\\+`/version `${nextRelease.version}`/g' template/{{.project_name}}/README.md.tmpl || true",
       },
     ],
     [

--- a/template/{{.project_name}}/.github/workflows/semantic-release.yml
+++ b/template/{{.project_name}}/.github/workflows/semantic-release.yml
@@ -24,13 +24,13 @@ jobs:
 
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: "main"     # Ensure you're on the main branch
           fetch-depth: 0  # Fetch all history and tags
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 20
 

--- a/template/{{.project_name}}/.gitignore
+++ b/template/{{.project_name}}/.gitignore
@@ -49,7 +49,6 @@ htmlcov/
 .cache
 nosetests.xml
 coverage.xml
-pytest_coverage.xml
 *.cover
 *.py,cover
 .hypothesis/


### PR DESCRIPTION
## Summary
Low-risk config hygiene surfaced by a repo audit. No behavioral change to generated projects.

- **Action pin parity** — The template's `semantic-release.yml` pinned `actions/checkout@v4` and `actions/setup-node@v4`, while the root repo already uses `@v5`. Bumped the template to match so generated projects don't ship older pins.
- **Dead sed target** — `release.config.mjs` ran its version-bump `sed` against both `README.md.tmpl` and `docs/README.md.tmpl`. Only `README.md.tmpl` contains a `` version `x.y.z` `` string; the `docs` target was a no-op. Removed it.
- **Vestigial gitignore entry** — `pytest_coverage.xml` was ignored in the template `.gitignore`, but nothing produces that file (the standard `coverage.xml` is already on the line above, and no config emits `pytest_coverage.xml`). Removed the dead line.

> Note: stray `.DS_Store` files were also found in the template tree, but they are untracked/gitignored, so there's nothing to commit — removed locally only.

## Test plan
- [ ] Confirm semantic-release workflow still runs on `main`
