### PR TITLE
refactor(accelerators): align devcontainer with just (drop Makefile flow)

### DIFF
--- a/accelerators/devcontainer/.devcontainer/Dockerfile
+++ b/accelerators/devcontainer/.devcontainer/Dockerfile
@@ -9,6 +9,9 @@ ENV EDITOR=nano \
     UV_CACHE_DIR=/uv-cache \
     UV_LINK_MODE=copy
 
+# Install just (the project's build-automation tool) if the base image lacks it
+RUN command -v just >/dev/null 2>&1 || curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to /usr/local/bin
+
 # Set the working directory
 WORKDIR /workspace/
 

--- a/accelerators/devcontainer/.devcontainer/devcontainer.json.tmpl
+++ b/accelerators/devcontainer/.devcontainer/devcontainer.json.tmpl
@@ -16,7 +16,6 @@
         "databricks.databricks",
         "ms-python.vscode-pylance",
         "ms-toolsai.jupyter",
-        "ms-vscode.makefile-tools",
         "njpwerner.autodocstring",
         "redhat.vscode-yaml",
         "tamasfe.even-better-toml",
@@ -30,5 +29,5 @@
       "terminal.integrated.defaultProfile.linux": "zsh"
     }
   },
-  "postCreateCommand": "make setup"
+  "postCreateCommand": "just setup"
 }

--- a/accelerators/devcontainer/ci-devcontainer.yml
+++ b/accelerators/devcontainer/ci-devcontainer.yml
@@ -81,12 +81,12 @@ jobs:
           echo "Pulling container image..."
           docker pull ${{ env.CONTAINER_REGISTRY }}/${{ github.repository_owner }}/${{ env.CONTAINER_NAME }}:${{ env.CONTAINER_TAG }}
 
-      # Mount the project directory and run Make commands inside the container
-      - name: Build and test Databricks Asset Bundle with Makefile in container
+      # Mount the project directory and run just recipes inside the container
+      - name: Build and test Databricks Asset Bundle with just in container
         run: |
           cd revo-dabs-devcontainer-test
           echo "Running commands in container..."
-          cat Makefile
+          cat .justfile
           cat pyproject.toml
           set -e
           docker run --rm \
@@ -113,27 +113,20 @@ jobs:
 
               echo \"\"
               echo \"==================================================================\"
-              echo \"=============== BUILD PROJECT (WITH DEFAULT TARGET) ==============\"
+              echo \"===================== ENSURE just IS AVAILABLE ===================\"
               echo \"==================================================================\"
-              make
+              command -v just >/dev/null 2>&1 || curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to /usr/local/bin
 
               echo \"\"
               echo \"==================================================================\"
-              echo \"================ SETUP PROJECT (WITH SETUP TARGET) ===============\"
+              echo \"===================== SETUP PROJECT (just setup) =================\"
               echo \"==================================================================\"
-              make setup
-
-              echo \"\"
-              echo \"==================================================================\"
-              echo \"=============== BUILD PROJECT (WITH BUILD TARGET) ================\"
-              echo \"==================================================================\"
-              make build
+              just setup
 
               echo \"\"
               echo \"==================================================================\"
               echo \"==================== COMMIT ALL FILES ============================\"
               echo \"==================================================================\"
-              uv run pre-commit autoupdate || true
               git add .
               git commit -m \"feat: initial commit\"
 
@@ -141,25 +134,25 @@ jobs:
               echo \"==================================================================\"
               echo \"======================== LINT PROJECT ============================\"
               echo \"==================================================================\"
-              make lint
+              just lint
 
               echo \"\"
               echo \"==================================================================\"
               echo \"========================= RUN TESTS ==============================\"
               echo \"==================================================================\"
-              make test
+              just test
 
               echo \"\"
               echo \"==================================================================\"
               echo \"======================== CLEAN PROJECT ===========================\"
               echo \"==================================================================\"
-              make clean
+              just clean
 
               echo \"\"
               echo \"==================================================================\"
               echo \"=============== RE-BUILD PROJECT (AFTER CLEAN) ===================\"
               echo \"==================================================================\"
-              make build
+              uv build
 
               echo \"\"
               echo \"==================================================================\"

--- a/accelerators/devcontainer/devcontainer.md
+++ b/accelerators/devcontainer/devcontainer.md
@@ -70,7 +70,7 @@ You need these tools installed on your system:
    databricks configure
    ```
 
-   This silently creates a `.databrickscfg` file in your home directory to authenticate the user. Note that the profile name is `DEFAULT` in this example. If you give it any other name, you will need to update it in the `Makefile`.
+   This silently creates a `.databrickscfg` file in your home directory to authenticate the user. Note that the profile name is `DEFAULT` in this example. If you give it any other name, set the `PROFILE_NAME` environment variable accordingly (e.g. in a `.env` file), which the project's `just` recipes pick up.
 
 4. **Clone Repo**
 
@@ -108,9 +108,9 @@ The container automatically mounts:
 Once your container is configured and running, you can:
 
 - Interact with Azure Repos using `git` commands
-- Run `PySpark` tests on `Databricks Connect` using the `make test` command
-- Deploy to Databricks using the `make deploy` command
-- Destroy Databricks resources using the `make destroy` command
+- Run `PySpark` tests on `Databricks Connect` using the `just test` command
+- Deploy to Databricks using the `just deploy` command
+- Destroy Databricks resources using the `just destroy` command
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary
Completes the migration that was previously deferred: the `devcontainer/` accelerator ran a **Makefile**-based flow, but generated projects ship a `.justfile` (no Makefile). Its CI literally `cat Makefile` + `make setup/build/lint/test/clean` — targets that don't exist in a generated project, so the make-flow was stale/broken. This aligns the accelerator with what's actually deployed (`just` + `prek`).

## Changes
- **`ci-devcontainer.yml`** — `make {setup,build,lint,test,clean}` → `just {setup,lint,test,clean}` + a `uv build` for the rebuild-after-clean step. Dropped the redundant "default target" and standalone "build target" steps (the core template has no `build` recipe — building happens inside `lint`/`test`/`validate`). Removed `uv run pre-commit autoupdate || true` (the prek-based `just setup` already installs/updates hooks). Added a guard that installs `just` if the pulled image doesn't already have it.
- **`devcontainer.json.tmpl`** — `postCreateCommand: "make setup"` → `"just setup"`; removed the now-irrelevant `ms-vscode.makefile-tools` recommendation.
- **`Dockerfile`** — install `just` if the base image lacks it, so the built container can run the recipes.
- **`devcontainer.md`** — `make test/deploy/destroy` → `just ...`; profile guidance now points to the `PROFILE_NAME` env var (used by `.just/dab.justfile`) instead of "edit the Makefile".

## ⚠️ Dependencies / things to confirm (please review)
1. **Depends on the ty PR (#116).** This is based on `main`, where mypy still fails the example pipeline, so `ci-devcontainer`'s commit step (which runs the type checker via prek) will be **red until #116 merges**. Once ty is on `main`, I'll rebase this and it should go green. (Same pre-existing-failure situation as the other cleanup PRs.)
2. **Base image must provide `just`.** `ci-devcontainer.yml` runs commands inside the prebuilt `revo-devcontainer-databricks` image (built in a separate repo), not the Dockerfile here. I added an in-CI `just` install guard so it works regardless, but ideally `just` is baked into that base image — worth confirming on your side.
3. **`accelerators/README.md` note.** PR #115 (not yet merged) adds a README saying this migration is "deferred". If both merge, that line is stale — I'll update it once #115 lands (or fold it in if you'd prefer).

## Test plan
- [ ] After #116 merges + rebase: `ci-devcontainer` renders, runs `just setup/lint/test/clean`, and validates the bundle green
- [ ] Confirm the prebuilt devcontainer base image has (or now installs) `just`
