### PR TITLE
ci: temporarily disable example job run tests in ci-dabs

### DIFF
--- a/.github/workflows/ci-dabs.yml
+++ b/.github/workflows/ci-dabs.yml
@@ -186,103 +186,107 @@ jobs:
           path: revo-dabs-test-project
           retention-days: 1
 
-  run-example-job:
-    needs: ci-dabs
-    if: success()
-    runs-on: ubuntu-latest
-    steps:
-      - name: Download project artifact
-        uses: actions/download-artifact@v5
-        with:
-          name: revo-dabs-test-project
-          path: revo-dabs-test-project
+# Temporarily disabled: running the deployed example jobs is fragile (shared
+# workspace accumulates stale duplicates, runs get canceled mid-flight) and slow.
+# To re-enable, uncomment both jobs and restore
+# `needs: [run-example-job, run-example-pipeline-job]` on destroy-bundle.
+#  run-example-job:
+#    needs: ci-dabs
+#    if: success()
+#    runs-on: ubuntu-latest
+#    steps:
+#      - name: Download project artifact
+#        uses: actions/download-artifact@v5
+#        with:
+#          name: revo-dabs-test-project
+#          path: revo-dabs-test-project
+#
+#      - name: Install Databricks CLI
+#        run: |
+#          curl -fsSL https://raw.githubusercontent.com/databricks/setup-cli/main/install.sh | sudo sh
+#          databricks version
+#
+#      - name: Run Example Job
+#        run: |
+#          cd revo-dabs-test-project
+#          echo ""
+#          echo "=================================================================="
+#          echo "======================== RUN EXAMPLE JOB ========================="
+#          echo "=================================================================="
+#          echo "Starting 'example-job' job... (this may take a while)"
+#          EXAMPLE_JOB_ID=$(databricks jobs list --output json | jq '.[] | select(.settings.name | contains("example-job")) | .job_id')
+#          echo "Example job ID: $EXAMPLE_JOB_ID"
+#
+#          if [ -z "$EXAMPLE_JOB_ID" ]; then
+#            echo "Error: Could not find example-job"
+#            databricks jobs list --output text
+#            exit 1
+#          fi
+#
+#          RESULT_STATE=$(databricks jobs run-now $EXAMPLE_JOB_ID | jq -r '.state.result_state')
+#          echo "Job result state: $RESULT_STATE"
+#
+#          if [[ "$RESULT_STATE" == "SUCCESS" ]]; then
+#            echo "Job completed successfully!"
+#          else
+#            echo "Job failed with status: $RESULT_STATE"
+#            exit 1
+#          fi
+#        env:
+#          DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
+#          DATABRICKS_CLIENT_ID: ${{ secrets.DATABRICKS_CLIENT_ID }}
+#          DATABRICKS_CLIENT_SECRET: ${{ secrets.DATABRICKS_CLIENT_SECRET }}
+#
+#  run-example-pipeline-job:
+#    needs: ci-dabs
+#    if: success()
+#    runs-on: ubuntu-latest
+#    steps:
+#      - name: Download project artifact
+#        uses: actions/download-artifact@v5
+#        with:
+#          name: revo-dabs-test-project
+#          path: revo-dabs-test-project
+#
+#      - name: Install Databricks CLI
+#        run: |
+#          curl -fsSL https://raw.githubusercontent.com/databricks/setup-cli/main/install.sh | sudo sh
+#          databricks version
+#
+#      - name: Run example pipeline job
+#        run: |
+#          cd revo-dabs-test-project
+#          echo ""
+#          echo "=================================================================="
+#          echo "================ RUN EXAMPLE PIPELINE JOB ========================"
+#          echo "=================================================================="
+#          echo "Starting 'example-pipeline-job'... (this may take a while)"
+#          PIPELINE_JOB_ID=$(databricks jobs list --output json | jq '.[] | select(.settings.name | contains("example-pipeline-job")) | .job_id')
+#          echo "Pipeline job ID: $PIPELINE_JOB_ID"
+#
+#          if [ -z "$PIPELINE_JOB_ID" ]; then
+#            echo "Error: Could not find example-pipeline-job"
+#            databricks jobs list --output text
+#            exit 1
+#          fi
+#
+#          PIPELINE_RESULT_STATE=$(databricks jobs run-now $PIPELINE_JOB_ID | jq -r '.state.result_state')
+#          echo "Pipeline result state: $PIPELINE_RESULT_STATE"
+#
+#          if [[ "$PIPELINE_RESULT_STATE" == "SUCCESS" ]]; then
+#            echo "Pipeline job completed successfully!"
+#          else
+#            echo "Pipeline job failed with status: $PIPELINE_RESULT_STATE"
+#            exit 1
+#          fi
+#        env:
+#          DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
+#          DATABRICKS_CLIENT_ID: ${{ secrets.DATABRICKS_CLIENT_ID }}
+#          DATABRICKS_CLIENT_SECRET: ${{ secrets.DATABRICKS_CLIENT_SECRET }}
 
-      - name: Install Databricks CLI
-        run: |
-          curl -fsSL https://raw.githubusercontent.com/databricks/setup-cli/main/install.sh | sudo sh
-          databricks version
-
-      - name: Run Example Job
-        run: |
-          cd revo-dabs-test-project
-          echo ""
-          echo "=================================================================="
-          echo "======================== RUN EXAMPLE JOB ========================="
-          echo "=================================================================="
-          echo "Starting 'example-job' job... (this may take a while)"
-          EXAMPLE_JOB_ID=$(databricks jobs list --output json | jq '.[] | select(.settings.name | contains("example-job")) | .job_id')
-          echo "Example job ID: $EXAMPLE_JOB_ID"
-
-          if [ -z "$EXAMPLE_JOB_ID" ]; then
-            echo "Error: Could not find example-job"
-            databricks jobs list --output text
-            exit 1
-          fi
-
-          RESULT_STATE=$(databricks jobs run-now $EXAMPLE_JOB_ID | jq -r '.state.result_state')
-          echo "Job result state: $RESULT_STATE"
-
-          if [[ "$RESULT_STATE" == "SUCCESS" ]]; then
-            echo "Job completed successfully!"
-          else
-            echo "Job failed with status: $RESULT_STATE"
-            exit 1
-          fi
-        env:
-          DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
-          DATABRICKS_CLIENT_ID: ${{ secrets.DATABRICKS_CLIENT_ID }}
-          DATABRICKS_CLIENT_SECRET: ${{ secrets.DATABRICKS_CLIENT_SECRET }}
-
-  run-example-pipeline-job:
-    needs: ci-dabs
-    if: success()
-    runs-on: ubuntu-latest
-    steps:
-      - name: Download project artifact
-        uses: actions/download-artifact@v5
-        with:
-          name: revo-dabs-test-project
-          path: revo-dabs-test-project
-
-      - name: Install Databricks CLI
-        run: |
-          curl -fsSL https://raw.githubusercontent.com/databricks/setup-cli/main/install.sh | sudo sh
-          databricks version
-
-      - name: Run example pipeline job
-        run: |
-          cd revo-dabs-test-project
-          echo ""
-          echo "=================================================================="
-          echo "================ RUN EXAMPLE PIPELINE JOB ========================"
-          echo "=================================================================="
-          echo "Starting 'example-pipeline-job'... (this may take a while)"
-          PIPELINE_JOB_ID=$(databricks jobs list --output json | jq '.[] | select(.settings.name | contains("example-pipeline-job")) | .job_id')
-          echo "Pipeline job ID: $PIPELINE_JOB_ID"
-
-          if [ -z "$PIPELINE_JOB_ID" ]; then
-            echo "Error: Could not find example-pipeline-job"
-            databricks jobs list --output text
-            exit 1
-          fi
-
-          PIPELINE_RESULT_STATE=$(databricks jobs run-now $PIPELINE_JOB_ID | jq -r '.state.result_state')
-          echo "Pipeline result state: $PIPELINE_RESULT_STATE"
-
-          if [[ "$PIPELINE_RESULT_STATE" == "SUCCESS" ]]; then
-            echo "Pipeline job completed successfully!"
-          else
-            echo "Pipeline job failed with status: $PIPELINE_RESULT_STATE"
-            exit 1
-          fi
-        env:
-          DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
-          DATABRICKS_CLIENT_ID: ${{ secrets.DATABRICKS_CLIENT_ID }}
-          DATABRICKS_CLIENT_SECRET: ${{ secrets.DATABRICKS_CLIENT_SECRET }}
-
-# Destroy bundle regardless of the outcome of both jobs
+# Destroy bundle regardless of the outcome of the deploy
   destroy-bundle:
-    needs: [run-example-job, run-example-pipeline-job]
+    needs: ci-dabs
     if: always()
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Why

The `run-example-job` and `run-example-pipeline-job` CI jobs are fragile and slow, and are currently blocking unrelated PRs (e.g. #119):

- They look up the deployed job by **name** (`databricks jobs list | jq ... contains(...)`) in a **shared** test workspace. Whenever a previous run's `destroy-bundle` step didn't complete (e.g. the deploy job failed, so no artifact was uploaded), stale duplicate jobs pile up, the lookup returns multiple IDs, and `jobs run-now` errors out.
- After cleaning up the stale duplicates, runs still fail: they get `USER_CANCELED` mid-flight during cluster startup (execution never begins), pointing at something in the workspace cancelling dev runs.
- Concurrent CI runs (multiple PRs, or double-triggers) deploy/destroy the **same** bundle (`revo-dabs-test-project`, same dev target, same service principal), racing each other's state — this is where the stale duplicates originally came from (four CI runs launched within 8 seconds on 2026-06-23).

## What

- Comment out `run-example-job` and `run-example-pipeline-job` (kept in place for easy re-enabling).
- `destroy-bundle` now depends directly on `ci-dabs` (still `if: always()`).

Template generation, bundle validation, deploy, and destroy are still fully tested across all 6 matrix configurations.

## Re-enabling later

The run step should be made robust before re-enabling, e.g.:
- use `databricks bundle run` inside the generated project instead of a workspace-wide name search, so only the bundle's own deployment is targeted
- add a `concurrency` group so only one CI run touches the shared workspace at a time

🤖 Generated with [Claude Code](https://claude.com/claude-code)