### PR TITLE
feat!: Declarative Automation Bundles rebrand + v1.0.0

### DIFF
--- a/.github/workflows/ci-dabs.yml
+++ b/.github/workflows/ci-dabs.yml
@@ -82,7 +82,7 @@ jobs:
       - name: Initialize Declarative Automation Bundle from template
         run: |
           echo "Using branch: $BRANCH_NAME"
-          databricks bundle init https://github.com/revodatanl/revo-asset-bundle-templates --branch $BRANCH_NAME --config-file init_params.json
+          databricks bundle init https://github.com/revodatanl/revo-dabs --branch $BRANCH_NAME --config-file init_params.json
         shell: bash
         env:
           DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}

--- a/.github/workflows/ci-dabs.yml
+++ b/.github/workflows/ci-dabs.yml
@@ -68,7 +68,7 @@ jobs:
         run: |
           echo '{
             "project_name": "revo-dabs-test-project",
-            "project_description": "This project is generated using our own RevoData Asset Bundle Templates.",
+            "project_description": "This project is generated using our own RevoData Declarative Automation Bundle Templates.",
             "author": "Thomas Brouwer",
             "email": "thomas.brouwer@revodata.nl",
             "setup_type": "tailored",
@@ -79,7 +79,7 @@ jobs:
             "support_windows": "${{ matrix.support_windows }}"
           }' > init_params.json
 
-      - name: Initialize Databricks Asset Bundle from template
+      - name: Initialize Declarative Automation Bundle from template
         run: |
           echo "Using branch: $BRANCH_NAME"
           databricks bundle init https://github.com/revodatanl/revo-asset-bundle-templates --branch $BRANCH_NAME --config-file init_params.json
@@ -96,7 +96,7 @@ jobs:
           pwsh -NoProfile -ExecutionPolicy Bypass -File "./.just/just_bash.ps1"
           cd ..
 
-      - name: Build and test Databricks Asset Bundle with justfile
+      - name: Build and test Declarative Automation Bundle with justfile
         run: |
           cd revo-dabs-test-project
           echo ""
@@ -156,7 +156,7 @@ jobs:
           DATABRICKS_CLIENT_ID: ${{ secrets.DATABRICKS_CLIENT_ID }}
           DATABRICKS_CLIENT_SECRET: ${{ secrets.DATABRICKS_CLIENT_SECRET }}
 
-      - name: Deploy Databricks Asset Bundle (using default runner only)
+      - name: Deploy Declarative Automation Bundle (using default runner only)
         if: |
           matrix.os == 'ubuntu-latest' &&
           matrix.cicd_provider == 'github' &&

--- a/.gitignore
+++ b/.gitignore
@@ -184,7 +184,7 @@ pyrightconfig.json
 # Ignore simulated Spark warehouse
 spark-warehouse/
 
-# Ignore Databricks Asset Bundles
+# Ignore Declarative Automation Bundles
 .databricks/
 scratch/**
 !scratch/README.md

--- a/.justfile
+++ b/.justfile
@@ -81,7 +81,7 @@ alias just-test := test-justfile
 
 PROFILE_NAME := env("PROFILE_NAME", "DEFAULT")
 
-# Initializes a new Databricks Asset Bundle project using the template. Tests whether the template is valid and passes checks.
+# Initializes a new Declarative Automation Bundle project using the template. Tests whether the template is valid and passes checks.
 # Note: this is the repo-root justfile, not the template's. The Databricks profile comes from
 # the `profile` argument (`just test-deploy MY_PROFILE`), defaulting to $PROFILE_NAME or "DEFAULT".
 [group('template')]
@@ -91,7 +91,7 @@ test-deploy profile=PROFILE_NAME:
 	mkdir -p temporary_deployment;
 	echo '{ \
 		"project_name": "temporary_deployment", \
-		"project_description": "This project is generated using our own RevoData Asset Bundle Templates.", \
+		"project_description": "This project is generated using our own RevoData Declarative Automation Bundle Templates.", \
 		"author": "Thomas Brouwer", \
 		"email": "thomas.brouwer@revodata.nl", \
 		"setup_type": "tailored", \
@@ -103,7 +103,7 @@ test-deploy profile=PROFILE_NAME:
 		"include_dab_recipes": "yes", \
 		"empower_vscode": "yes" \
 		}' > temporary_deployment/init_params.json;
-	echo "Initializing a new Databricks Asset Bundle from template...";
+	echo "Initializing a new Declarative Automation Bundle from template...";
 	databricks bundle init . --config-file "temporary_deployment/init_params.json" -p {{ profile }};
 	echo "Switching to deployed template folder and running setup...";
 	cd "temporary_deployment" && just -f ../.justfile run-temporary-deployment-tests;

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ To contribute to this GitHub project, you can follow these steps:
 
     **Internal contributors**:
     1. Run the following command from your terminal:
-        `git clone https://github.com/revodatanl/revo-asset-bundle-templates.git`
+        `git clone https://github.com/revodatanl/revo-dabs.git`
     2. Create a feature branch using the following command:
         `git checkout -b "branch-name"`
 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)
 [![semantic-release: angular](https://img.shields.io/badge/semantic--release-angular-e10079?logo=semantic-release)](https://github.com/semantic-release/semantic-release)
 
-[![CI](https://github.com/revodatanl/revo-asset-bundle-templates/actions/workflows/ci-dabs.yml/badge.svg)](https://github.com/revodatanl/revo-asset-bundle-templates/actions/workflows/ci-dabs.yml)
-[![semantic-release](https://github.com/revodatanl/revo-asset-bundle-templates/actions/workflows/semantic-release.yml/badge.svg)](https://github.com/revodatanl/revo-asset-bundle-templates/actions/workflows/semantic-release.yml)
+[![CI](https://github.com/revodatanl/revo-dabs/actions/workflows/ci-dabs.yml/badge.svg)](https://github.com/revodatanl/revo-dabs/actions/workflows/ci-dabs.yml)
+[![semantic-release](https://github.com/revodatanl/revo-dabs/actions/workflows/semantic-release.yml/badge.svg)](https://github.com/revodatanl/revo-dabs/actions/workflows/semantic-release.yml)
 ![just](https://img.shields.io/badge/%F0%9F%A4%96%20just-%3E1.25-000000?style=plastic&color=lime&link=https%3A%2F%2Fjust.systems%2Fman%2Fen%2F)
 
 The `RevoData Declarative Automation Bundle Templates` repo contains our own custom templates for Declarative Automation Bundles (formerly Databricks Asset Bundles). The template provides a complete development environment for new Databricks projects, including CI/CD pipelines, pre-commit hooks, semantic release, and example pipelines and jobs that can directly be deployed to Databricks.
@@ -38,7 +38,7 @@ This template solves common pain points in Databricks project setup:
 2. Initialize a new project using the template:
 
     ```bash
-    databricks bundle init https://github.com/revodatanl/revo-asset-bundle-templates
+    databricks bundle init https://github.com/revodatanl/revo-dabs
     ```
 
     ![bundle-init](images/bundle-init.png)
@@ -93,7 +93,7 @@ Key development files:
 Test locally using:
 
 ```bash
-databricks bundle init https://github.com/revodatanl/revo-asset-bundle-templates --branch <branch_name>
+databricks bundle init https://github.com/revodatanl/revo-dabs --branch <branch_name>
 ```
 
 Changes are protected by comprehensive CI-DABS pipeline testing all template configurations.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ This template solves common pain points in Databricks project setup:
 - **Modular Architecture**: Core template is lightweight, with experimental accelerators (work in progress) for specialized needs
 - **CI/CD Ready**: Complete pipelines for GitHub Actions and Azure DevOps
 - **Development Environment**: DevContainer and WSL support for consistent development across platforms
+- **Aligned with Databricks**: follows Databricks' March 2026 [rename](https://docs.databricks.com/aws/en/dev-tools/bundles/faqs) to Declarative Automation Bundles — the `databricks bundle` CLI and the DAB acronym are unchanged
 
 ## Getting started
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# RevoData Asset Bundle Templates
+# RevoData Declarative Automation Bundle Templates
 
 ![Databricks Runtime](https://img.shields.io/badge/Databricks%20Runtime-16.4--LTS-%231B3139)
 [![python](https://img.shields.io/badge/python-3.12-g)](https://www.python.org)
@@ -12,7 +12,7 @@
 [![semantic-release](https://github.com/revodatanl/revo-asset-bundle-templates/actions/workflows/semantic-release.yml/badge.svg)](https://github.com/revodatanl/revo-asset-bundle-templates/actions/workflows/semantic-release.yml)
 ![just](https://img.shields.io/badge/%F0%9F%A4%96%20just-%3E1.25-000000?style=plastic&color=lime&link=https%3A%2F%2Fjust.systems%2Fman%2Fen%2F)
 
-The `RevoData Asset Bundle Templates` repo contains our own custom templates for Databricks Asset Bundles. The template provides a complete development environment for new Databricks projects, including CI/CD pipelines, pre-commit hooks, semantic release, and example pipelines and jobs that can directly be deployed to Databricks.
+The `RevoData Declarative Automation Bundle Templates` repo contains our own custom templates for Declarative Automation Bundles (formerly Databricks Asset Bundles). The template provides a complete development environment for new Databricks projects, including CI/CD pipelines, pre-commit hooks, semantic release, and example pipelines and jobs that can directly be deployed to Databricks.
 
 ## Why This Template?
 
@@ -48,7 +48,7 @@ This template solves common pain points in Databricks project setup:
     | Parameter | Description | Example | Condition |
     | --------- | ----------- | ------- | --------- |
     | `project_name` | Name of the project (usually the same as the repository name) | `revo-dabs-test-project` | |
-    | `project_description` | Brief description of the project | `This project is generated using our own RevoData Asset Bundle Templates.` | |
+    | `project_description` | Brief description of the project | `This project is generated using our own RevoData Declarative Automation Bundle Templates.` | |
     | `author` | Name of the author | `Thomas Brouwer` | |
     | `email` | Email address of the author | `thomas.brouwer@revodata.nl` | |
     | `setup_type` | Type of setup (`default`, `minimal` or `tailored`) | `default` | |
@@ -82,7 +82,7 @@ This template solves common pain points in Databricks project setup:
 
 ## Developing the Template
 
-Databricks Asset Bundle Templates use `Go` template syntax with conditional logic based on the parameters above.
+Declarative Automation Bundle Templates use `Go` template syntax with conditional logic based on the parameters above.
 
 Key development files:
 

--- a/accelerators/Makefile
+++ b/accelerators/Makefile
@@ -5,8 +5,8 @@
 # Interactive module deployment - select and deploy template accelerators
 accelerator:
 	@echo "Select the accelerator to deploy:"
-	@echo "1) Deploy Databricks Asset Bundle pipeline for GitHub"
-	@echo "2) Deploy Databricks Asset Bundle pipeline for Azure DevOps"
+	@echo "1) Deploy Declarative Automation Bundle pipeline for GitHub"
+	@echo "2) Deploy Declarative Automation Bundle pipeline for Azure DevOps"
 	@echo "Enter the number of the accelerator you want to deploy: "
 	@read choice; \
 	case "$$choice" in \

--- a/accelerators/Makefile
+++ b/accelerators/Makefile
@@ -25,7 +25,7 @@ accelerator_%:
 		set -e; \
 		trap 'if [ -f databricks.yml.bak ]; then mv databricks.yml.bak databricks.yml; fi' EXIT; \
 		if [ -f databricks.yml ]; then mv databricks.yml databricks.yml.bak; fi; \
-		if ! databricks bundle init https://github.com/revodatanl/revo-asset-bundle-templates --template-dir accelerators/$* 2>&1; then \
+		if ! databricks bundle init https://github.com/revodatanl/revo-dabs --template-dir accelerators/$* 2>&1; then \
 			echo "Exiting." >&2; \
 		fi; \
 	}

--- a/accelerators/devcontainer/ci-devcontainer.yml
+++ b/accelerators/devcontainer/ci-devcontainer.yml
@@ -54,7 +54,7 @@ jobs:
           EOF
           cat init_params.json
 
-      - name: Initialize Databricks Asset Bundle from template
+      - name: Initialize Declarative Automation Bundle from template
         run: |
           echo "Using branch: $BRANCH_NAME"
           databricks bundle init https://github.com/revodatanl/revo-asset-bundle-templates --branch $BRANCH_NAME --config-file init_params.json
@@ -82,7 +82,7 @@ jobs:
           docker pull ${{ env.CONTAINER_REGISTRY }}/${{ github.repository_owner }}/${{ env.CONTAINER_NAME }}:${{ env.CONTAINER_TAG }}
 
       # Mount the project directory and run just recipes inside the container
-      - name: Build and test Databricks Asset Bundle with just in container
+      - name: Build and test Declarative Automation Bundle with just in container
         run: |
           cd revo-dabs-devcontainer-test
           echo "Running commands in container..."

--- a/accelerators/devcontainer/ci-devcontainer.yml
+++ b/accelerators/devcontainer/ci-devcontainer.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Initialize Declarative Automation Bundle from template
         run: |
           echo "Using branch: $BRANCH_NAME"
-          databricks bundle init https://github.com/revodatanl/revo-asset-bundle-templates --branch $BRANCH_NAME --config-file init_params.json
+          databricks bundle init https://github.com/revodatanl/revo-dabs --branch $BRANCH_NAME --config-file init_params.json
         env:
           DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
           DATABRICKS_CLIENT_ID: ${{ secrets.DATABRICKS_CLIENT_ID }}
@@ -67,7 +67,7 @@ jobs:
         run: |
           cd revo-dabs-devcontainer-test
           echo "Deploying DevContainer accelerator..."
-          databricks bundle init https://github.com/revodatanl/revo-asset-bundle-templates --template-dir accelerators/devcontainer --branch $BRANCH_NAME
+          databricks bundle init https://github.com/revodatanl/revo-dabs --template-dir accelerators/devcontainer --branch $BRANCH_NAME
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3

--- a/accelerators/devcontainer/devcontainer.md
+++ b/accelerators/devcontainer/devcontainer.md
@@ -1,6 +1,6 @@
 # Setting up a Development Environment with DevContainers
 
-This document explains how to set up a consistent development environment for Databricks Asset Bundles using DevContainers. This approach works on **Windows**, **macOS**, and **Linux** with minimal setup requirements.
+This document explains how to set up a consistent development environment for Declarative Automation Bundles using DevContainers. This approach works on **Windows**, **macOS**, and **Linux** with minimal setup requirements.
 
 This approach sets up Databricks Runtime, Python environment, development tools, VS Code extensions, and configuration to match your production environment. This guide has been written with **Windows** and **Azure DevOps** users in mind.
 

--- a/databricks_template_schema.json
+++ b/databricks_template_schema.json
@@ -1,10 +1,10 @@
 {
-  "welcome_message": "Welcome to RevoData Asset Bundle Templates!",
+  "welcome_message": "Welcome to RevoData Declarative Automation Bundle Templates!",
   "min_databricks_cli_version": "v0.236.0",
   "properties": {
     "project_name": {
       "type": "string",
-      "description": "{{if false}}\n\nERROR: This template is not supported by your current Databricks CLI version.\nPlease hit control-C and go to https://docs.databricks.com/en/dev-tools/cli/install.html for instructions on upgrading the CLI to the minimum version (v0.236.0) supported by RevoData Asset Bundle Templates.\n\n\n{{end}}Project name",
+      "description": "{{if false}}\n\nERROR: This template is not supported by your current Databricks CLI version.\nPlease hit control-C and go to https://docs.databricks.com/en/dev-tools/cli/install.html for instructions on upgrading the CLI to the minimum version (v0.236.0) supported by RevoData Declarative Automation Bundle Templates.\n\n\n{{end}}Project name",
       "order": 1,
       "pattern": "^[A-Za-z0-9_-]+$",
       "pattern_match_failure_message": "Project name must consist of letters, numbers, dashes, or underscores."

--- a/databricks_template_schema.json
+++ b/databricks_template_schema.json
@@ -1,10 +1,10 @@
 {
   "welcome_message": "Welcome to RevoData Declarative Automation Bundle Templates!",
-  "min_databricks_cli_version": "v0.236.0",
+  "min_databricks_cli_version": "v0.295.0",
   "properties": {
     "project_name": {
       "type": "string",
-      "description": "{{if false}}\n\nERROR: This template is not supported by your current Databricks CLI version.\nPlease hit control-C and go to https://docs.databricks.com/en/dev-tools/cli/install.html for instructions on upgrading the CLI to the minimum version (v0.236.0) supported by RevoData Declarative Automation Bundle Templates.\n\n\n{{end}}Project name",
+      "description": "{{if false}}\n\nERROR: This template is not supported by your current Databricks CLI version.\nPlease hit control-C and go to https://docs.databricks.com/en/dev-tools/cli/install.html for instructions on upgrading the CLI to the minimum version (v0.295.0) supported by RevoData Declarative Automation Bundle Templates.\n\n\n{{end}}Project name",
       "order": 1,
       "pattern": "^[A-Za-z0-9_-]+$",
       "pattern_match_failure_message": "Project name must consist of letters, numbers, dashes, or underscores."

--- a/template/{{.project_name}}/.azure/.azure-pipelines/cd.yml
+++ b/template/{{.project_name}}/.azure/.azure-pipelines/cd.yml
@@ -23,10 +23,10 @@ variables:
 
 stages:
   - stage: deploy_test
-    displayName: Deploy Databricks Asset Bundle to test environment
+    displayName: Deploy Declarative Automation Bundle to test environment
     jobs:
       - deployment: deploy_Databricks_Asset_Bundle_test
-        displayName: Deploy Databricks Asset Bundle to `test`
+        displayName: Deploy Declarative Automation Bundle to `test`
         variables:
           - group: ${{ variables.groupName }}_test
         environment: ${{ variables.environmentName }}_test
@@ -56,11 +56,11 @@ stages:
             displayName: Manual validation
 
   - stage: deploy_prod
-    displayName: Deploy Databricks Asset Bundle to prod environment
+    displayName: Deploy Declarative Automation Bundle to prod environment
     dependsOn: wait_for_approval
     jobs:
       - deployment: deploy_Databricks_Asset_Bundle_prod
-        displayName: Deploy Databricks Asset Bundle to `prod`
+        displayName: Deploy Declarative Automation Bundle to `prod`
         variables:
           - group: ${{ variables.groupName }}_prod
         environment: ${{ variables.environmentName }}_prod

--- a/template/{{.project_name}}/.github/workflows/cd.yml
+++ b/template/{{.project_name}}/.github/workflows/cd.yml
@@ -1,4 +1,4 @@
-name: Deploy Databricks Asset Bundle
+name: Deploy Declarative Automation Bundle
 
 # Before using this pipeline:
 # 1. Update variables: groupName, environmentName, keyVaultName, azureSubscription

--- a/template/{{.project_name}}/.gitignore
+++ b/template/{{.project_name}}/.gitignore
@@ -184,7 +184,7 @@ pyrightconfig.json
 # Ignore simulated Spark warehouse
 spark-warehouse/
 
-# Ignore Databricks Asset Bundles
+# Ignore Declarative Automation Bundles
 .databricks/
 scratch/**
 !scratch/README.md

--- a/template/{{.project_name}}/.justfile
+++ b/template/{{.project_name}}/.justfile
@@ -17,7 +17,7 @@ set dotenv-load
 # We have to set the temp directory to prevent OS specific fallbacks that are not always available.
 set tempdir := ".just"
 
-# Imports Databricks Asset Bundle related recipes if they are deployed.
+# Imports Declarative Automation Bundle related recipes if they are deployed.
 import? '.just/dab.justfile'
 
 # Imports VS Code related recipes if they are deployed.

--- a/template/{{.project_name}}/README.md.tmpl
+++ b/template/{{.project_name}}/README.md.tmpl
@@ -10,7 +10,7 @@
 
 {{.project_description}}
 
-The `{{.project_name}}` project was generated from [RevoData Asset Bundle Templates](https://github.com/revodatanl/revo-asset-bundle-templates) version `0.20.0`.
+The `{{.project_name}}` project was generated from [RevoData Declarative Automation Bundle Templates](https://github.com/revodatanl/revo-asset-bundle-templates) version `0.20.0`.
 
 ## Prerequisites
 
@@ -51,7 +51,7 @@ Comprehensive documentation can be found in the [documentation](docs/README.md).
 
 - **[Getting Started](docs/getting_started.md)** - Set up your development environment
 - **[Development](docs/development.md)** - Project structure, configuration, code quality, and (testing on) Databricks Connect
-- **[Bundle Deployment](docs/bundle_deployment.md)** - Databricks Asset Bundle deployment, Git strategy, and CI/CD
+- **[Bundle Deployment](docs/bundle_deployment.md)** - Deployment of Declarative Automation Bundles (formerly Databricks Asset Bundles), Git strategy, and CI/CD
 - **[Coding Standards](docs/coding_standard.md)** - Code style and conventions
 
 ## Troubleshooting

--- a/template/{{.project_name}}/README.md.tmpl
+++ b/template/{{.project_name}}/README.md.tmpl
@@ -10,7 +10,7 @@
 
 {{.project_description}}
 
-The `{{.project_name}}` project was generated from [RevoData Declarative Automation Bundle Templates](https://github.com/revodatanl/revo-asset-bundle-templates) version `0.20.0`.
+The `{{.project_name}}` project was generated from [RevoData Declarative Automation Bundle Templates](https://github.com/revodatanl/revo-dabs) version `0.20.0`.
 
 ## Prerequisites
 

--- a/template/{{.project_name}}/docs/README.md.tmpl
+++ b/template/{{.project_name}}/docs/README.md.tmpl
@@ -17,7 +17,7 @@
 ## Development
 
 - **[Development](development.md)** - Project structure, configuration, code quality, and (testing on) Databricks Connect
-- **[Bundle Deployment](bundle_deployment.md)** - Databricks Asset Bundle deployment, Git strategy, and CI/CD
+- **[Bundle Deployment](bundle_deployment.md)** - Declarative Automation Bundle deployment, Git strategy, and CI/CD
 
 ## Appendices
 

--- a/template/{{.project_name}}/docs/bundle_deployment.md.tmpl
+++ b/template/{{.project_name}}/docs/bundle_deployment.md.tmpl
@@ -1,6 +1,6 @@
 # Deployment
 
-[Databricks Asset Bundles](https://docs.databricks.com/aws/en/dev-tools/bundles/) enable software engineering best practices for data and AI projects through source control, code review, testing, and CI/CD.
+[Declarative Automation Bundles](https://docs.databricks.com/aws/en/dev-tools/bundles/) enable software engineering best practices for data and AI projects through source control, code review, testing, and CI/CD.
 Bundles define your entire project—structure, tests, and deployment—as source files, making collaboration seamless.
 
 A bundle contains:
@@ -120,14 +120,14 @@ The `CI` pipeline ensures code quality and bundle functionality before merging.
 
 ### Continuous Deployment (CD)
 
-The `CD` pipeline automates Databricks Asset Bundle deployments across environments. The pipeline ensures consistent deployments while maintaining proper governance through environment-specific configurations and approval workflows.
+The `CD` pipeline automates Declarative Automation Bundle deployments across environments. The pipeline ensures consistent deployments while maintaining proper governance through environment-specific configurations and approval workflows.
 
 **Trigger**: Merge to main branch
 **Pipeline**: {{if (eq .cicd_provider "azure")}}`.azure/.azure-pipelines/cd.yml`{{end}}{{if (eq .cicd_provider "github")}}`.github/workflows/cd.yml`{{end}}
 
 **Flow**:
 
-1. Automatic Databricks Asset Bundle deployment to test environment
+1. Automatic Declarative Automation Bundle deployment to test environment
 2. Integration test execution
 3. Manual approval gate (12-hour timeout)
 4. Production deployment upon approval (**from `main` for jobs/pipelines; from `release/*` for models**)

--- a/template/{{.project_name}}/docs/development.md.tmpl
+++ b/template/{{.project_name}}/docs/development.md.tmpl
@@ -32,7 +32,7 @@ Projects include three key configuration files that work together to define the 
 
 ### databricks.yml
 
-The Databricks Asset Bundle configuration:
+The Declarative Automation Bundle configuration:
 
 - **Bundle name**: Uses the project name from template parameters
 - **Artifact configuration**: Defines Python wheel packaging using `uv build` with dynamic versioning

--- a/template/{{.project_name}}/docs/wsl.md
+++ b/template/{{.project_name}}/docs/wsl.md
@@ -69,7 +69,7 @@ You need these tools installed on your system:
    ```bash
    mkdir ~/code
    cd ~/code
-   databricks bundle init https://github.com/revodatanl/revo-asset-bundle-templates
+   databricks bundle init https://github.com/revodatanl/revo-dabs
    ```
 
    Follow the prompts to configure your project. This will create a new project directory with all necessary files.

--- a/template/{{.project_name}}/docs/wsl.md
+++ b/template/{{.project_name}}/docs/wsl.md
@@ -1,6 +1,6 @@
 # Setting up a Development Environment with WSL
 
-This document explains how to set up a consistent development environment for Databricks Asset Bundles using Windows Subsystem for Linux (WSL).
+This document explains how to set up a consistent development environment for Declarative Automation Bundles using Windows Subsystem for Linux (WSL).
 
 ### Why Not Native Windows?
 
@@ -64,7 +64,7 @@ You need these tools installed on your system:
 
 4. **Initialize a New Project from Template**
 
-   Create a new project using the Databricks Asset Bundle template:
+   Create a new project using the Declarative Automation Bundle template:
 
    ```bash
    mkdir ~/code


### PR DESCRIPTION
## Summary

Adopts Databricks' March 2026 rename of **Databricks Asset Bundles → Declarative Automation Bundles** ([Databricks FAQ](https://docs.databricks.com/aws/en/dev-tools/bundles/faqs)) across all documentation, prompts, and template output, and graduates the template to **v1.0.0** via semantic-release.

- `docs:` commit — prose sweep across 17 files: README, template schema (welcome message + CLI error text), root & template justfiles/gitignores, `ci-dabs.yml` step names, accelerators (Makefile prompts, devcontainer CI + docs), template README and docs, and both CD pipelines' display names.
- `feat!:` commit — raises `min_databricks_cli_version` from `v0.236.0` to **`v0.295.0`** ([the CLI release that shipped the rename](https://github.com/databricks/cli/releases/tag/v0.295.0); this is the breaking change driving the major version) and adds a "Why This Template?" note linking the rename FAQ.

**Not** changed: `databricks bundle` CLI invocations, YAML keys, Go-template directives, resource keys, just/make target names, the `CI DABs` workflow/job names, the Azure `deploy_Databricks_Asset_Bundle_*` deployment identifiers, `CHANGELOG.md`, and the DAB/Revo-DABs acronyms. The `` version `X.Y.Z` `` string in the template README stays byte-compatible with the semantic-release `prepareCmd` sed pattern.

## Verification

- `grep -ri "asset bundle"` (excl. CHANGELOG) leaves exactly **2 intentional** "(formerly Databricks Asset Bundles)" mentions — root README intro and template README
- `databricks_template_schema.json` parses; `skip_prompt_if` / `{{if false}}` logic untouched
- Smoke-rendered all three setup types with CLI v1.4.0 (`default`, `minimal`, `tailored` azure+cicd+examples): correct new branding, no stray old-name prose, version string intact; re-rendered after rebasing on current main
- `prek run --all-files` green; `just test-justfile` green; diff is prose/display-names only

## ⚠️ Merge instructions

Semantic-release cuts **v1.0.0** from the `BREAKING CHANGE:` footer. **Use a merge commit**, or if squashing, **paste the `BREAKING CHANGE:` footer into the squash commit body** — otherwise only a minor release is cut.

## Remaining items

- [x] **Repo renamed to `revodatanl/revo-dabs`** — the org ruleset that blocked the rename was temporarily disabled and has since been **re-enabled**. The in-repo URL updates landed as the `chore:` commit on this PR (7 files, 11 references; CHANGELOG compare links intentionally untouched). GitHub redirects the old slug.
- [ ] Repo description updated ✔; **social preview image** still to be refreshed (GitHub UI)
- [ ] `images/bundle-init.png` screenshot still shows the old welcome message (non-blocking)
- [ ] Post-release: Medium/LinkedIn announcement
- [x] Future PR: move actual deploy/run-example jobs to a post-merge (push-to-main) workflow, re-enabling what #120 disabled → **#122** (merge after this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
